### PR TITLE
Add optional TLS support and HTTPS guidance

### DIFF
--- a/yt-proxy/README.md
+++ b/yt-proxy/README.md
@@ -9,7 +9,15 @@ npm install
 YT_API_KEY=your-key-here node server.js
 ```
 
-By default the server listens on port `3000`. Configure `ALLOWED_ORIGIN` to restrict browser access and `PORT` to customize the listener port.
+By default the server listens on port `3000`. Configure `ALLOWED_ORIGIN` to restrict browser access and `PORT` to customize the listener port. For hardened transport security you can run the proxy over HTTPS by supplying the following environment variables:
+
+- `TLS_KEY_FILE`: absolute path to your private key (PEM).
+- `TLS_CERT_FILE`: absolute path to the certificate that pairs with the private key (PEM).
+- `TLS_CA_FILE` *(optional)*: bundle of intermediate certificates to present to clients.
+- `REQUIRE_TLS`: set to `true` to require HTTPS and redirect any plain HTTP requests to the secure endpoint.
+- `SERVER_TIMEOUT_MS` *(optional)*: request timeout (defaults to 15000 ms) to reduce the impact of slow‑loris style attacks.
+
+When `REQUIRE_TLS` is enabled the server will refuse to start unless both `TLS_KEY_FILE` and `TLS_CERT_FILE` are present, ensuring it never falls back to an insecure transport. Behind a reverse proxy or load balancer you can omit the TLS files and terminate TLS at the edge; keep `REQUIRE_TLS` unset in that scenario.
 
 If you update dependencies, re-run `npm install` (or `npm install --package-lock-only`) so `package-lock.json` stays in sync for deployments.
 

--- a/yt-proxy/server.js
+++ b/yt-proxy/server.js
@@ -3,6 +3,9 @@ import helmet from 'helmet';
 import morgan from 'morgan';
 import fetch from 'node-fetch';
 import dotenv from 'dotenv';
+import http from 'http';
+import https from 'https';
+import { readFileSync } from 'fs';
 
 dotenv.config();
 
@@ -10,6 +13,11 @@ const app = express();
 const allowedOrigin = process.env.ALLOWED_ORIGIN;
 const apiKey = process.env.YT_API_KEY;
 const port = Number(process.env.PORT) || 3000;
+const requireTls = process.env.REQUIRE_TLS === 'true';
+const tlsKeyPath = process.env.TLS_KEY_FILE;
+const tlsCertPath = process.env.TLS_CERT_FILE;
+const tlsCaPath = process.env.TLS_CA_FILE;
+const serverTimeoutMs = Number(process.env.SERVER_TIMEOUT_MS) || 15000;
 
 const allowedResources = new Set(['search', 'videos', 'channels', 'playlists']);
 
@@ -91,8 +99,30 @@ const safeParams = {
   ])
 };
 
-app.use(helmet());
+app.disable('x-powered-by');
+
+const helmetMiddleware = helmet({
+  referrerPolicy: { policy: 'strict-origin-when-cross-origin' }
+});
+
+app.use(helmetMiddleware);
 app.use(morgan('combined'));
+
+if (requireTls) {
+  app.enable('trust proxy');
+  app.use((req, res, next) => {
+    if (req.secure) {
+      return next();
+    }
+
+    const host = req.headers.host;
+    if (!host) {
+      return res.status(400).json({ error: 'HTTPS required' });
+    }
+
+    return res.redirect(301, `https://${host}${req.originalUrl}`);
+  });
+}
 
 app.use((req, res, next) => {
   if (!allowedOrigin) {
@@ -189,6 +219,45 @@ app.use((req, res) => {
   res.status(404).json({ error: 'Not found' });
 });
 
-app.listen(port, () => {
-  console.log(`YouTube proxy listening on port ${port}`);
+let server;
+
+const buildHttpsServer = () => {
+  if (!tlsKeyPath || !tlsCertPath) {
+    if (requireTls) {
+      console.error('REQUIRE_TLS is true but TLS_KEY_FILE or TLS_CERT_FILE is missing.');
+      process.exit(1);
+    }
+
+    return null;
+  }
+
+  try {
+    const httpsOptions = {
+      key: readFileSync(tlsKeyPath),
+      cert: readFileSync(tlsCertPath),
+      minVersion: 'TLSv1.2'
+    };
+
+    if (tlsCaPath) {
+      httpsOptions.ca = readFileSync(tlsCaPath);
+    }
+
+    return https.createServer(httpsOptions, app);
+  } catch (error) {
+    console.error('Failed to load TLS materials:', error.message);
+    process.exit(1);
+  }
+};
+
+server = buildHttpsServer();
+
+if (!server) {
+  server = http.createServer(app);
+}
+
+server.setTimeout(serverTimeoutMs);
+
+server.listen(port, () => {
+  const protocol = server instanceof https.Server ? 'https' : 'http';
+  console.log(`YouTube proxy listening on ${protocol.toUpperCase()} port ${port}`);
 });


### PR DESCRIPTION
## Summary
- add optional TLS configuration with HTTPS server startup, request timeouts, and redirect support when required
- harden the Express app by disabling the X-Powered-By header and tightening the referrer policy
- document the new security-focused environment variables in the README so operators can enable HTTPS safely

## Testing
- node server.js *(fails: missing local npm dependencies in the execution environment)*
- npm install *(fails: registry access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ef4e71a894832bafbacdfd95f13836