### PR TITLE
Switch to custom video player with proxied streams

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,6 +226,7 @@
             border: none;
             border-radius: calc(var(--border-radius) - 4px);
             background: #000;
+            display: block;
         }
 
         .player-placeholder {
@@ -286,15 +287,16 @@
         </section>
 
         <section class="player-wrapper" aria-label="Video player">
-            <iframe
+            <video
                 id="player"
                 class="player-frame"
-                title="YouTube video player"
-                src=""
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                allowfullscreen>
-            </iframe>
-            <p class="player-placeholder" id="player-placeholder">Select a video above to start playback. The player supports fullscreen mode.</p>
+                preload="metadata"
+                controls
+                playsinline
+                tabindex="-1"
+                aria-label="Selected video playback">
+            </video>
+            <p class="player-placeholder" id="player-placeholder">Select a video above to start playback. The built-in player uses non-YouTube streams when available.</p>
         </section>
     </main>
 
@@ -307,8 +309,9 @@
             const searchButton = document.getElementById('search-button');
             const resultsContainer = document.getElementById('results');
             const statusDisplay = document.getElementById('status');
-            const playerFrame = document.getElementById('player');
+            const playerElement = document.getElementById('player');
             const playerPlaceholder = document.getElementById('player-placeholder');
+            const defaultPlaceholderText = playerPlaceholder.textContent;
 
             let sessionApiKey = '';
             let activeCard = null;
@@ -316,6 +319,19 @@
             const setStatus = (message, isError = false) => {
                 statusDisplay.textContent = message;
                 statusDisplay.classList.toggle('error', Boolean(isError));
+            };
+
+            const resetPlayer = () => {
+                try {
+                    playerElement.pause();
+                } catch (error) {
+                    // Ignore pause errors
+                }
+                playerElement.removeAttribute('src');
+                playerElement.load();
+                delete playerElement.dataset.videoId;
+                playerPlaceholder.hidden = false;
+                playerPlaceholder.textContent = defaultPlaceholderText;
             };
 
             const enableSearch = () => {
@@ -345,14 +361,121 @@
                 }
             };
 
-            const loadVideo = (videoId) => {
+            const fetchStreamInfo = async (videoId) => {
+                const providers = [
+                    `/api/piped/streams/${encodeURIComponent(videoId)}`,
+                    `https://piped.video/api/v1/streams/${encodeURIComponent(videoId)}`
+                ];
+
+                let lastError = null;
+
+                for (const endpoint of providers) {
+                    try {
+                        const response = await fetch(endpoint, {
+                            headers: { Accept: 'application/json' }
+                        });
+
+                        if (!response.ok) {
+                            throw new Error(`Stream provider responded with status ${response.status}`);
+                        }
+
+                        const data = await response.json();
+
+                        if (data && typeof data === 'object') {
+                            return data;
+                        }
+
+                        throw new Error('Stream provider returned an unexpected payload.');
+                    } catch (error) {
+                        lastError = error;
+                    }
+                }
+
+                throw lastError || new Error('No stream providers are currently reachable.');
+            };
+
+            const selectStreamUrl = (info) => {
+                if (!info || typeof info !== 'object') {
+                    return '';
+                }
+
+                if (typeof info.hls === 'string' && info.hls.length > 0) {
+                    return info.hls;
+                }
+
+                const streams = Array.isArray(info.videoStreams) ? info.videoStreams : [];
+
+                const playable = streams
+                    .filter((stream) => {
+                        if (!stream || typeof stream !== 'object') {
+                            return false;
+                        }
+
+                        if (stream.videoOnly) {
+                            return false;
+                        }
+
+                        const mimeType = typeof stream.mimeType === 'string' ? stream.mimeType : '';
+                        return /video\/mp4/i.test(mimeType);
+                    })
+                    .map((stream) => {
+                        const qualityText = typeof stream.quality === 'string' ? stream.quality : '';
+                        const qualityMatch = qualityText.match(/(\d+)/);
+                        const qualityValue = qualityMatch ? Number(qualityMatch[1]) : 0;
+                        return { ...stream, __qualityValue: qualityValue };
+                    })
+                    .sort((a, b) => (b.__qualityValue || 0) - (a.__qualityValue || 0));
+
+                if (playable.length > 0 && typeof playable[0].url === 'string') {
+                    return playable[0].url;
+                }
+
+                return '';
+            };
+
+            const loadVideo = async (videoId, title = '') => {
                 if (!videoId) {
                     return;
                 }
-                playerFrame.src = `https://www.youtube.com/embed/${encodeURIComponent(videoId)}?rel=0&autoplay=1`;
-                playerPlaceholder.hidden = true;
-                if (typeof playerFrame.focus === 'function') {
-                    playerFrame.focus({ preventScroll: true });
+
+                resetPlayer();
+
+                const displayTitle = title || 'selected video';
+                playerPlaceholder.hidden = false;
+                playerPlaceholder.textContent = 'Fetching a stream for the selected video…';
+                setStatus(`Loading stream for ${displayTitle}…`);
+
+                try {
+                    const streamInfo = await fetchStreamInfo(videoId);
+                    const streamUrl = selectStreamUrl(streamInfo);
+
+                    if (!streamUrl) {
+                        throw new Error('No compatible streams were returned for playback.');
+                    }
+
+                    playerElement.src = streamUrl;
+                    playerElement.dataset.videoId = videoId;
+                    playerPlaceholder.hidden = true;
+
+                    const playPromise = playerElement.play();
+                    if (playPromise && typeof playPromise.catch === 'function') {
+                        playPromise.catch(() => {
+                            // Autoplay may be blocked; user can press play manually.
+                        });
+                    }
+
+                    if (typeof playerElement.focus === 'function') {
+                        playerElement.focus({ preventScroll: true });
+                    }
+
+                    setStatus(`Now playing: ${displayTitle}`);
+                } catch (error) {
+                    resetPlayer();
+                    const youtubeUrl = `https://www.youtube.com/watch?v=${encodeURIComponent(videoId)}`;
+                    playerPlaceholder.hidden = false;
+                    playerPlaceholder.innerHTML = `Unable to load a privacy-friendly stream right now. <a href="${youtubeUrl}" target="_blank" rel="noopener noreferrer">Open this video on YouTube</a>.`;
+                    console.error(error);
+                    setStatus(error.message || 'Failed to load the selected video.', true);
                 }
             };
 
@@ -398,14 +521,13 @@
                 card.append(thumbnail, info);
 
                 card.addEventListener('click', () => {
-                    loadVideo(videoId);
+                    void loadVideo(videoId, snippet.title);
                     if (activeCard) {
                         activeCard.classList.remove('is-selected');
                     }
                     card.classList.add('is-selected');
                     activeCard = card;
-                    setStatus(`Now playing: ${snippet.title || 'Selected video'}`);
-                    playerFrame.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                    playerElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
                 });
 
                 return card;

--- a/yt-proxy/README.md
+++ b/yt-proxy/README.md
@@ -9,7 +9,7 @@ npm install
 YT_API_KEY=your-key-here node server.js
 ```
 
-By default the server listens on port `3000`. Configure `ALLOWED_ORIGIN` to restrict browser access and `PORT` to customize the listener port.
+By default the server listens on port `3000`. Configure `ALLOWED_ORIGIN` to restrict browser access and `PORT` to customize the listener port. Set `PIPED_INSTANCE` to point at an alternative [Piped](https://github.com/TeamPiped/Piped) deployment if you want to proxy video streams through a non-default host.
 
 If you update dependencies, re-run `npm install` (or `npm install --package-lock-only`) so `package-lock.json` stays in sync for deployments.
 
@@ -17,10 +17,14 @@ If you update dependencies, re-run `npm install` (or `npm install --package-lock
 
 - **Build command:** `npm ci`
 - **Start command:** `node server.js`
-- Set `YT_API_KEY`, `ALLOWED_ORIGIN`, and `PORT` (optional) in your Render environment.
+- Set `YT_API_KEY`, `ALLOWED_ORIGIN`, `PIPED_INSTANCE` (optional), and `PORT` (optional) in your Render environment.
 
 ## Example request
 
 ```bash
 curl "https://<render-url>/api/yt/search?part=snippet&q=cats"
 ```
+
+### Streaming proxy
+
+The `/api/piped/streams/:videoId` endpoint relays JSON metadata from the configured Piped instance and can be used by clients to discover direct MP4 or HLS streams for playback in a custom player.

--- a/yt-proxy/README.md
+++ b/yt-proxy/README.md
@@ -9,7 +9,7 @@ npm install
 YT_API_KEY=your-key-here node server.js
 ```
 
-By default the server listens on port `3000`. Configure `ALLOWED_ORIGIN` to restrict browser access and `PORT` to customize the listener port. Set `PIPED_INSTANCE` to point at an alternative [Piped](https://github.com/TeamPiped/Piped) deployment if you want to proxy video streams through a non-default host.
+By default the server listens on port `3000`. Configure `ALLOWED_ORIGIN` to restrict browser access and `PORT` to customize the listener port. Set `PIPED_INSTANCE` to point at an alternative [Piped](https://github.com/TeamPiped/Piped) deployment if you want to proxy video streams through a non-default host. When you deploy the proxy as a standalone service (for example on Render) it also serves the project root `index.html`, so the UI and API can live on the same host without additional static hosting.
 
 If you update dependencies, re-run `npm install` (or `npm install --package-lock-only`) so `package-lock.json` stays in sync for deployments.
 

--- a/yt-proxy/server.js
+++ b/yt-proxy/server.js
@@ -10,6 +10,7 @@ const app = express();
 const allowedOrigin = process.env.ALLOWED_ORIGIN;
 const apiKey = process.env.YT_API_KEY;
 const port = Number(process.env.PORT) || 3000;
+const pipedInstance = (process.env.PIPED_INSTANCE || 'https://piped.video').replace(/\/+$/, '');
 
 const allowedResources = new Set(['search', 'videos', 'channels', 'playlists']);
 
@@ -182,6 +183,39 @@ app.get('/api/yt/:resource', async (req, res) => {
     res.status(response.status).json(data);
   } catch (error) {
     res.status(500).json({ error: 'Failed to reach YouTube API', details: error.message });
+  }
+});
+
+app.get('/api/piped/streams/:videoId', async (req, res) => {
+  const rawVideoId = typeof req.params.videoId === 'string' ? req.params.videoId.trim() : '';
+
+  if (!rawVideoId || !/^[a-zA-Z0-9_-]{6,}$/u.test(rawVideoId)) {
+    return res.status(400).json({ error: 'Invalid video identifier provided.' });
+  }
+
+  const upstreamUrl = `${pipedInstance}/api/v1/streams/${encodeURIComponent(rawVideoId)}`;
+
+  try {
+    const response = await fetch(upstreamUrl, {
+      headers: { Accept: 'application/json' }
+    });
+
+    const text = await response.text();
+    let data;
+
+    try {
+      data = JSON.parse(text);
+    } catch (parseError) {
+      return res
+        .status(502)
+        .json({ error: 'Invalid JSON response from stream provider', details: parseError.message });
+    }
+
+    res.status(response.status).json(data);
+  } catch (error) {
+    res
+      .status(502)
+      .json({ error: 'Failed to reach stream provider', details: error.message });
   }
 });
 

--- a/yt-proxy/server.js
+++ b/yt-proxy/server.js
@@ -3,6 +3,9 @@ import helmet from 'helmet';
 import morgan from 'morgan';
 import fetch from 'node-fetch';
 import dotenv from 'dotenv';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 dotenv.config();
 
@@ -13,6 +16,24 @@ const port = Number(process.env.PORT) || 3000;
 const pipedInstance = (process.env.PIPED_INSTANCE || 'https://piped.video').replace(/\/+$/, '');
 
 const allowedResources = new Set(['search', 'videos', 'channels', 'playlists']);
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const indexPath = path.resolve(currentDir, '..', 'index.html');
+let cachedIndexHtml;
+
+const loadIndexHtml = async () => {
+  try {
+    if (cachedIndexHtml) {
+      return cachedIndexHtml;
+    }
+
+    cachedIndexHtml = await readFile(indexPath, 'utf8');
+    return cachedIndexHtml;
+  } catch (error) {
+    cachedIndexHtml = undefined;
+    throw error;
+  }
+};
 
 const safeParams = {
   search: new Set([
@@ -122,8 +143,14 @@ app.use((req, res, next) => {
   return res.status(403).json({ error: 'Origin not allowed' });
 });
 
-app.get('/', (req, res) => {
-  res.send('ok');
+app.get('/', async (req, res, next) => {
+  try {
+    const html = await loadIndexHtml();
+    res.set('Content-Type', 'text/html; charset=utf-8');
+    res.send(html);
+  } catch (error) {
+    next(error);
+  }
 });
 
 app.get('/api/yt/:resource', async (req, res) => {
@@ -219,8 +246,19 @@ app.get('/api/piped/streams/:videoId', async (req, res) => {
   }
 });
 
-app.use((req, res) => {
+app.use((req, res, next) => {
+  if (res.headersSent) {
+    return next();
+  }
   res.status(404).json({ error: 'Not found' });
+});
+
+app.use((error, req, res, next) => {
+  console.error('Unhandled error', error);
+  if (res.headersSent) {
+    return next(error);
+  }
+  res.status(500).json({ error: 'Internal server error' });
 });
 
 app.listen(port, () => {


### PR DESCRIPTION
## Summary
- replace the embedded YouTube iframe with an HTML5 video element that loads non-YouTube streams
- add client-side helpers to fetch stream metadata via a proxied Piped endpoint and fall back gracefully when unavailable
- extend the proxy server to expose /api/piped/streams and document the new PIPED_INSTANCE configuration option

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ef524822b4832b9cbd149d6a5e9a31